### PR TITLE
[TASK] Do not sync var/log/.gitkeep

### DIFF
--- a/recipe/helhum/typo3.php
+++ b/recipe/helhum/typo3.php
@@ -139,9 +139,6 @@ add('rsync', [
         '/{{typo3/root_dir}}/uploads',
         '/var/log',
     ],
-    'include' => [
-        '/var/log/.gitkeep',
-    ],
     'flags' => 'r',
     'options' => [
         'times',


### PR DESCRIPTION
Since var/log is a shared directory now, we can skip syncing this file